### PR TITLE
Update opentelemetry.yml

### DIFF
--- a/roles/my-use-case/files/platform/applications/platform/opentelemetry.yml
+++ b/roles/my-use-case/files/platform/applications/platform/opentelemetry.yml
@@ -45,6 +45,22 @@ spec:
                     endpoint: "0.0.0.0:4317" # https://github.com/open-telemetry/opentelemetry-helm-charts/issues/222#issuecomment-1149259626
                   http:
                     endpoint: "0.0.0.0:4318"
+            processors:
+              cumulativetodelta: {}
+              resource:
+                attributes:
+                - key: telemetry.sdk.name
+                  value: opentelemetry
+                  action: insert
+                - key: dynatrace.otel.collector
+                  value: hot-day-platform-engineering-daemonset
+                  action: insert
+                - key: dt.security_context
+                  value: hot-day-platform-engineering
+                  action: insert
+                - key: k8s.cluster.name
+                  value: hot-day-platform-engineering
+                  action: insert
             exporters:
               otlphttp:
                 endpoint: "$DT_URL/api/v2/otlp"
@@ -54,14 +70,15 @@ spec:
               pipelines:
                 traces:
                   receivers: [otlp]
-                  processors: []
+                  processors: [resource]
                   exporters: [otlphttp]
                 metrics:
                   receivers: [otlp]
-                  processors: []
+                  processors: [resource,cumulativetodelta]
                   exporters: [otlphttp]
                 logs:
-                 exporters: [otlphttp]
+                  processors: [resource]
+                  exporters: [otlphttp]
   destination:
     namespace: opentelemetry
     server: 'https://kubernetes.default.svc'


### PR DESCRIPTION
Added resource and cumulativetodelta processors.

The `resource` processor will:
- populate `telemetry.sdk.name` resource attribute with `opentelemetry` value
- populate `dynatrace.otel.collector` resource attribute with `hot-day-platform-engineering-daemonset` value
- populate `dt.security_context` resource attribute with `hot-day-platform-engineering` value
- populate `k8s.cluster.name` resource attribute with `hot-day-platform-engineering` value

The `cumulativetodelta` processor will:
- convert cumulative sum metrics, which are unsupported, to delta metrics
- remove partial success warnings from collector logs caused by these errors