### PR TITLE
Update rollout.yml

### DIFF
--- a/roles/my-use-case/files/apptemplates/simplenodeservice-content/manifests/rollout.yml
+++ b/roles/my-use-case/files/apptemplates/simplenodeservice-content/manifests/rollout.yml
@@ -47,7 +47,7 @@ spec:
         - name: DT_CUSTOM_PROP
           value: "owner=${{ values.teamIdentifier }} project=${{ values.projectName }} stage=${{ values.releaseStage }}"
         - name: DT_TAGS
-          value: "dt.owner=${{ values.teamIdentifier }}"
+          value: "dt.owner=${{ values.teamIdentifier }} dt.cost.costcenter=${{ values.teamIdentifier }} dt.cost.product=${{ values.projectName }}-${{ values.releaseStage }}"
         ports:
         - name: http
           containerPort: 8080


### PR DESCRIPTION
- added dt.cost.costcenter and dt.cost.product tags

Full stack monitoring for app-only monitoring mode doesn't support cost allocation yet, but we can still show the tags.